### PR TITLE
chore: GlobalStyle 문서에 색상변수 추가

### DIFF
--- a/harudoyak/src/style/GlobalStyle.tsx
+++ b/harudoyak/src/style/GlobalStyle.tsx
@@ -2,11 +2,15 @@ import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
 
-  /* CSS 변수 정의 (필요에 따라 추가 가능) */
   :root {
-    --main-bg-color: #ffffff;
-    --main-font-color: #333333;
-    --link-color: #1e90ff;
+    --main-green: #3C7960;
+    --background: #F2F6F3;
+    --sub-green1: #60927D;
+    --sub-green2: #7DB49D;
+    --sub-green3: #A5CBBC;
+    --white-from-grayscale: #ffffff;
+    --gray-from-grayscale: #A6A6A6;
+    --darkgray-from-grayscale: #6d6d6d;
   }
 
   /* 기본적인 HTML 요소의 초기화 */


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)



## 📝작업 내용
GlobalStyle에 색상 변수 추가 
아래 스크린샷에 사용 방법 첨부하였습니다.

## 스크린샷(선택)
### 색상변수 사용 방법
아래 코드와 같이 피그마 라이브러리에 추가된 style 색상을 변수명으로 부여하여 추가했습니다. 
<img width="399" alt="스크린샷 2024-10-22 오후 4 11 22" src="https://github.com/user-attachments/assets/b3e7770e-eab0-4e69-bc7c-2646b4e7859b">



styled-component에서의 색상 변수 사용 예시입니다.
색상을 사용해야 할 때 `var(--main-green)` 을 넣어주시면 됩니다. 
<img width="363" alt="스크린샷 2024-10-22 오후 4 11 26" src="https://github.com/user-attachments/assets/25c996a8-39df-40c2-bdb0-462308a927ef">




## 💬리뷰 요구사항 / 질문(선택)
위 사용 방법 읽어주시면 감사하겠습니다. 


