### PR TITLE
feat: CenterTextHeader 컴포넌트 구현, 1025(금) 작업현황 공유

### DIFF
--- a/harudoyak/src/components/buttons/UndoXButton.tsx
+++ b/harudoyak/src/components/buttons/UndoXButton.tsx
@@ -6,7 +6,6 @@
 // 최초 작성일/작성자: 2024.10.25./루이
 // 수정일/작성자: 
 
-
 import { useRouter } from 'next/router';
 import iconX from "../../../public/assets/grow-up-record/icon_X.svg";
 import Image from "next/image";

--- a/harudoyak/src/components/buttons/UndoXButton.tsx
+++ b/harudoyak/src/components/buttons/UndoXButton.tsx
@@ -1,7 +1,11 @@
 // 컴포넌트 이름: UndoXButton
 // 컴포넌트 설명: 'X' 모양 버튼
 // 주 사용처: 도약 기록하기 상단, 전체 페이지 내 X 모양의 undo 아이콘에 사용 가능 
-// 최초 작성자: 루이
+
+// Dev Log
+// 최초 작성일/작성자: 2024.10.25./루이
+// 수정일/작성자: 
+
 
 import { useRouter } from 'next/router';
 import iconX from "../../../public/assets/grow-up-record/icon_X.svg";

--- a/harudoyak/src/components/common/Header/CenterTextHeader.tsx
+++ b/harudoyak/src/components/common/Header/CenterTextHeader.tsx
@@ -1,3 +1,11 @@
+// 컴포넌트 이름: CenterTextHeader
+// 컴포넌트 설명: 좌측: X / 중앙: Heading Text / 우측: 작은 완료 버튼이 들어간 상단 헤더
+// 주 사용처: '도약기록 쓰기', 회원가입 flow에서 활용 가능
+
+// Dev Log
+// 최초 작성일/작성자: 2024.10.25./루이
+// 수정일/작성자: 
+
 import React from "react";
 import styled from "styled-components";
 import Link from "next/link";

--- a/harudoyak/src/components/common/Header/CenterTextHeader.tsx
+++ b/harudoyak/src/components/common/Header/CenterTextHeader.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+
+import UndoXButton from "../../buttons/UndoXButton";
+import CenterTextHeaderBtn from "./CenterTextHeaderBtn";
+
+const CenterTextHeader: React.FC = () => {
+  return (
+    <>
+      <HeaderWrapper>
+        <UndoXButton />
+        <Heading3>도약기록 쓰기</Heading3>
+        <Link href='/grow-check'><CenterTextHeaderBtn /></Link>
+        {/* TIP: href 속성에 라우팅하고 싶은 페이지 링크 작성*/}
+      </HeaderWrapper>
+    </>
+  );
+};
+
+export default CenterTextHeader;
+
+// styled components
+const HeaderWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 23px;
+`;
+const Heading3 = styled.h3`
+  color: var(--main-green);
+  font-size: 1.25rem;
+`;

--- a/harudoyak/src/components/common/Header/CenterTextHeaderBtn.tsx
+++ b/harudoyak/src/components/common/Header/CenterTextHeaderBtn.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styled from "styled-components";
+
+const CenterTextHeaderBtn: React.FC = () => {
+  return (
+    <>
+      <Button>완료</Button>
+    </>
+  );
+};
+
+export default CenterTextHeaderBtn;
+
+// styled components
+const Button = styled.button`
+  display: flex;
+  display: flex;
+  color: #ffffff;
+  background-color: var(--sub-green2);
+  border-radius: 20px;
+  width: 15%;
+  min-width: 57px;
+  height: 30px;
+  text-align: center;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.88rem;
+`;

--- a/harudoyak/src/components/grow-up-record/Emotions.tsx
+++ b/harudoyak/src/components/grow-up-record/Emotions.tsx
@@ -33,7 +33,7 @@ const Emotions: React.FC = () => {
         $isSelected={clickedEmotion === 1}
         onClick={() => handleClick(1)}
       >
-        <Image style={{}}src={emotion1} alt="사랑" />
+        <Image src={emotion1} alt="사랑" />
       </StyledBtn>
       <StyledBtn
         $isSelected={clickedEmotion === 2}
@@ -82,26 +82,25 @@ export default Emotions;
 
 // styled-components
 const Root = styled.div`
-  min-height: 80vh; /* 화면 전체 높이 -> TODO: 논의 후 화면 최대/최소 높이 확정하기 */
   padding: 0;
   max-width: 1100px;
 `;
 
 const StyledBtn = styled.button<{ $isSelected: boolean }>`
-  width: 2.75rem;
-  height: 2.75rem;
-  margin-right: 2%;
+  display: inline-block;
+  padding: 6px 6px;
+  line-height: normal;
+  text-align: center;
+  cursor: pointer;
+  width: auto;
+  height: 0 auto;
+  margin-right: 0.7%;
   border: 0px;
   border-radius: 10px;
   background: ${({ $isSelected }) => ($isSelected ? "#ebebeb" : "#F2F6F3")};
 
-  display: inline-block;
-  padding: 2px 2px;
-  margin: 0;
-  line-height: normal;
-  text-align: center;
-  cursor: pointer;
-
+  box-shadow: ${({ $isSelected }) => ($isSelected ? '1px 1px 2px 0px rgba(0, 0, 0, 0.1)': 'none')};
+  
   &:hover {
     background: #ebebeb;
   }
@@ -113,4 +112,3 @@ const PopMessage = styled.div`
   margin-top: 10px;
   margin-left: 12px;
 `;
-

--- a/harudoyak/src/components/grow-up-record/TextEntryButton.tsx
+++ b/harudoyak/src/components/grow-up-record/TextEntryButton.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+
+const TextEntryButton: React.FC = () => {
+  return (
+    <Root>
+      <EntryButton>
+        <Span>이 곳을 눌러 도약기록을 작성해 주세요.</Span>
+      </EntryButton>
+    </Root>
+  );
+};
+
+export default TextEntryButton;
+
+const Root = styled.div`
+  margin-right: 23px;
+`;
+
+const EntryButton = styled.button`
+  background: #ffffff;
+  width: 100%;
+  min-height: 100px;
+  border-radius: 10px;
+  border: 0.05px solid #b5d6bf;
+  padding: 0 10px; 
+  color: var(--gray-from-grayscale);
+  font-size: 0.94rem;
+  display: flex;
+  align-items: flex-start;
+  margin-right: 23px;
+`;
+
+const Span = styled.span`
+  display: block;
+  margin-top: 10px;
+`;

--- a/harudoyak/src/pages/grow-up-record/index.tsx
+++ b/harudoyak/src/pages/grow-up-record/index.tsx
@@ -1,22 +1,30 @@
 import React from "react";
 import styled from "styled-components";
+import Link from "next/link";
+
+import UndoXButton from "../../components/buttons/UndoXButton";
 
 import Emotions from "../../components/grow-up-record/Emotions";
-import UndoXButton from '../../components/buttons/UndoXButton';
+import TextEntryButton from '../../components/grow-up-record/TextEntryButton';
 
 const GrowUpRecordHome: React.FC = () => {
   return (
     <Root>
-      <UndoXButton />
+      <div style={{ width: '100%', display: 'flex', flexDirection: 'row-reverse' }}> 
+        <UndoXButton />
+      </div>
       <Heading3>오늘의 도약을 기록해 주세요.</Heading3>
       <Heading2>오늘의 감정</Heading2>
       <Emotions />
+      <Heading2 style={{marginBottom: '8px'}}>오늘의 도약 기록</Heading2>
+      <Link href='/writing-page'><TextEntryButton/></Link>
     </Root>
   );
 };
 
 export default GrowUpRecordHome;
 
+// styled-component
 const Root = styled.div`
   min-height: 80vh; /* Viewport Height, 화면 전체 높이 */
   padding: 0;
@@ -26,11 +34,12 @@ const Root = styled.div`
   @media screen and (max-width: 768px) {
     //모바일 환경
     margin-left: 1.44rem;
+    margin-right: 1.44rem;
   }
   @media screen and (min-width: 768px) {
     //pc 환경
     margin-left: 1.44rem;
-    margin-right: 220px;
+    margin-right: 1.44rem;
   }
 `;
 
@@ -42,4 +51,6 @@ const Heading3 = styled.h3`
 const Heading2 = styled.h2`
   font-size: 1.56rem;
   color: var(--sub-green2);
+  margin-bottom: 12px;
+  margin-top: 30px;
 `;

--- a/harudoyak/src/pages/writing-page/index.tsx
+++ b/harudoyak/src/pages/writing-page/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+
+import TextCenterHeader from "../../components/common/Header/CenterTextHeader";
+
+const WritingPage: React.FC = () => {
+  return (
+    <>
+      <TextCenterHeader />
+      <Input></Input>
+    </>
+  );
+};
+
+export default WritingPage;
+
+// styled-component
+const Input = styled.input``;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가 (Feat)


## 📝작업 내용
1. **CenterTextHeader 컴포넌트 작업 완료 (commom)**
 -컴포넌트 설명: 좌측: X / 중앙: Heading Text / 우측: 작은 완료 버튼이 들어간 상단 헤더
 -주 사용처: '도약기록 쓰기', 회원가입 flow에서 활용 가능
 -저장 위치: src/components/commom/Header/CenterTextHeader.tsx
 _*안에 들어가는 Xicon과 "완료" 버튼도 components 폴더 내에서 확인 가능합니다!_ 

2.  **CenterTextHeader 안에 들어가는 완료 작은 버튼(CenterTextHeaderBtn) 구현** 
 -컴포넌트 이름: CenterTextHeaderBtn
 -컴포넌트 설명: CenterTextHeader 우측 가장자리에 들어가는 작은 '완료' 버튼 
 -주 사용처: '도약기록 쓰기', 회원가입 flow 등에서 활용 가능
 -저장 위치: src/components/commom/Header/CenterTextHeaderBtn.tsx

3. **WritngPage로 연결되는 TextEntryButton 구현**
 next/link의 <Link>로 WrtingPage 라우팅 완료

4. **감정 기록하기+TextEntryButton 전체 style 점검**


## 스크린샷(선택)
CenterTextHeader: 상단 헤더를 봐주시면 됩니다. 
![스크린샷 2024-10-25 오후 5 24 11](https://github.com/user-attachments/assets/953e6d3b-2989-4154-bb53-5d605606a23d)

1025(금) 작업현황 공유

https://github.com/user-attachments/assets/2e1484ce-c190-4fbb-b358-95da4cc6b0fa



## 💬리뷰 요구사항 / 질문(선택)
텍스트 작성을 위한 WrtingPage를 구현할 때,
`pages`>`grow-up-record 폴더` 안에 추가로 파일을 만들었더니
해당 폴더 안에서 index 파일 외에는, Link 태그를 활용한 라우팅은 물론 주소창에 `localhost:3000/파일이름` 해도 새로 추가한 페이지를 찾지 못하는 것 같았습니다. (404 error)

이에, 우선 도약기록 쓰기 flow 내의 writing 페이지도 따로 pages에 새로운 폴더(pages/`writing-page/index.tsx` 폴더)를 만들어 index.tsx에서 구현하고 있습니다. 
혹시 페이지 간 라우팅에 대해 더 현명한 방법을 알고 계시다면 공유해 주시면 감사하겠습니다!

그 외 컴포넌트 관련 사항이나 리뷰사항 있으면 언제든 리뷰 달아주시면 빠르게 확인하겠습니다! 


## TODO(선택, 다음 작업 예고)
- [ ] Writing Page UI 구현 마무리
- [ ] Navigation Bar 작업 시작하기
- [ ] 글자수 모달 만들면서 기본 modal component 디자인하기
- [ ] grow-up-record 전체 flow 화면 구성 완료하기