### PR TITLE
feat: Home 화면 - 기록 작성된 날짜에 체크박스 추가 테스트 / 로그인 이전 화면에 로그인 버튼 추가

### DIFF
--- a/harudoyak/public/assets/home/checkBox.svg
+++ b/harudoyak/public/assets/home/checkBox.svg
@@ -1,0 +1,5 @@
+<svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="11.7231" height="12.6462" stroke="#F2F6F3"/>
+<rect width="12.7231" height="13.6462" fill="#60927D"/>
+<path d="M2.72656 5.00134L6.09444 8.18546L10.9057 3.63672" stroke="#F2F6F3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/harudoyak/src/components/home/HomeLoginButton.tsx
+++ b/harudoyak/src/components/home/HomeLoginButton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
+
+const Button = styled.button`
+
+border: none;
+display: flex;
+
+width: 100%;
+height: 48px;
+justify-content: center;
+align-items: center;
+align-self: stretch;
+border-radius: 24px;
+background: var(--main-green);
+
+color: var(--white-from-grayscale);
+font-family: Roboto;
+font-size: 16px;
+font-style: normal;
+font-weight: 500;
+line-height: 100%; /* 16px */
+letter-spacing: 0.5px;
+
+  cursor: pointer;
+  margin-bottom: 2rem;
+
+  &:hover {
+    background-color: var(--sub-green1);
+  }
+`;
+
+const LoginButton: React.FC = () => {
+  const router = useRouter();
+
+  return (
+    <Button onClick={() => router.push('/log-in') }>로그인</Button>
+  );
+};
+
+export default LoginButton;

--- a/harudoyak/src/components/home/MonthlyCalendar.tsx
+++ b/harudoyak/src/components/home/MonthlyCalendar.tsx
@@ -3,17 +3,50 @@ import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import styled from "styled-components";
 import moment from "moment";
+import Image from "next/image";
+import checkBox from "../../../public/assets/home/checkBox.svg";
+import { useRouter } from 'next/router';
 
 type ValuePiece = Date | null;
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
 const MonthlyCalendar: React.FC = () => {
-  const today = new Date();
+  const today: Date = new Date(); // 현재 날짜 및 시간
   const [date, setDate] = useState<Value>(today);
+  // 기록 작성된 일자 (테스트용으로 날짜 임시 지정)
+  const recordOn = ["2023-09-15", "2024-09-15", "2024-10-15", "2024-10-20", "2024-10-29", "2024-10-31"];
+  const recordDayList = [];
+
+  // api에서 response 받아와서 recordDayList 로 만들어줄 예정
+  // creationDate 값들만 추출하여 배열로 만들어줌
+  // response.data.map(item => item.creationDate) 
+
+  const router = useRouter();
 
   const handleDateChange = (newDate: Value) => {
     setDate(newDate);
+    console.log(date, typeof(date), today, typeof(today));
   };
+  const handleDateClick = (value) => {
+    console.log(value, typeof(date), date, typeof(date));
+
+    const formattedValue = value.toISOString().split("T")[0];
+    const formattedToday = today.toISOString().split("T")[0];
+
+    switch (true) {
+      // 작성된 기록 있음 - 일간 기록 확인 페이지로 이동
+      case (recordDayList.includes(formattedValue)):
+        router.push('/grow-check')
+      // 작성된 기록 없음 && 클릭한 날짜가 오늘 - 기록 작성 페이지로 이동
+      case (!recordDayList.includes(formattedValue) && value === formattedToday):
+        router.push('/grow-up-record')
+      // 작성된 기록 없음 && 클릭한 날짜가 오늘이 아님 - 모달 팝업
+      case (!recordDayList.includes(formattedValue) && value !== formattedToday):
+        return (
+          <div>모달 예시</div>
+        );
+    }
+  }
 
   return (
     <StyledCalendarWrapper>
@@ -29,6 +62,19 @@ const MonthlyCalendar: React.FC = () => {
         next2Label={null} // +1년 & +10년 이동 버튼 숨기기
         prev2Label={null} // -1년 & -10년 이동 버튼 숨기기
         minDetail="year" // 10년단위 년도 숨기기
+        onClickDay={(value: Date) => {
+          console.log("Selected day:", value); // 선택한 날짜 출력
+          handleDateClick(value); // 선택한 날짜에 대한 추가 처리
+        }}
+        tileContent={({ date }) => {
+            let html = [];
+            if (
+                recordOn.find((x) => x === moment(date).format("YYYY-MM-DD"))
+              ) {
+            html.push(<StyledCheckbox className="checkbox" src={checkBox} alt="recorded" key={moment(date).format("YYYY-MM-DD")} />)
+            }
+            return <>{html}</>
+        }}
       />
     </StyledCalendarWrapper>
   );
@@ -43,7 +89,7 @@ const StyledCalendarWrapper = styled.div`
   justify-content: center;
   position: relative;
   .react-calendar {
-    width: 90%;
+    width: 100%;
     border: none;
     border-radius: 0.5rem;
     box-shadow: 4px 2px 10px 0px rgba(0, 0, 0, 0.13);
@@ -73,23 +119,30 @@ const StyledCalendarWrapper = styled.div`
   .react-calendar__navigation button {
     font-weight: 800;
     font-size: 1rem;
+    text-align: center;
     color: var(--darkgray-from-grayscale);
   }
 
   /* 네비게이션 버튼 컬러 */
   .react-calendar__navigation button:focus {
-    background-color: white;
+    background-color: var(--white-from-grayscale);
   }
 
   /* 네비게이션 비활성화 됐을때 스타일 */
   .react-calendar__navigation button:disabled {
-    background-color: white;
-    color: ${(props) => props.theme.darkBlack};
+    background-color: var(--white-from-grayscale);
+    color: var(--darkgray-from-grayscale);
   }
 
   /* 년/월 상단 네비게이션 칸 크기 줄이기 */
   .react-calendar__navigation__label {
+    text-align: center;
     flex-grow: 0 !important;
+  }
+
+  /* 년/월 상단 네비게이션 > 버튼 설정 */
+  react-calendar__navigation__arrow react-calendar__navigation__next-button {
+    padding: 10%
   }
 
   /* 요일 밑줄 제거 */
@@ -98,7 +151,15 @@ const StyledCalendarWrapper = styled.div`
     font-weight: 800;
   }
 
-  /* 오늘 날짜 폰트 컬러 */
+  /* 선택한 날짜 스타일 적용 */
+  .react-calendar__tile:enabled:hover,
+  .react-calendar__tile:enabled:focus,
+  .react-calendar__tile--active {
+  background-color: var(--background);
+  border-radius: 0.3rem;
+  }  
+
+  /* 오늘 날짜 하이라이트 */
   .react-calendar__tile--now {
     background: var(--sub-green3);
     border-radius: 0.3rem;
@@ -107,22 +168,26 @@ const StyledCalendarWrapper = styled.div`
   /* 네비게이션 월 스타일 적용 */
   .react-calendar__year-view__months__month {
     border-radius: 0.8rem;
-    background-color: ${(props) => props.theme.gray_5};
+    background-color: var(--white-from-grayscale);
     padding: 0;
   }
 
   /* 네비게이션 현재 월 스타일 적용 */
   .react-calendar__tile--hasActive {
-    background-color: ${(props) => props.theme.primary_2};
+    background-color: var(--sub-green3);
     abbr {
-      color: white;
+      color: var(--white-from-grayscale);
     }
   }
 
   /* 일 날짜 간격 */
   .react-calendar__tile {
+    min-height: 46px; 
     padding: 5px 0px 18px;
     position: relative;
+    img {
+      margin: 3
+    }
   }
 
   /* 네비게이션 월 스타일 적용 */
@@ -134,20 +199,16 @@ const StyledCalendarWrapper = styled.div`
     padding: 20px 6.6667px;
     font-size: 0.9rem;
     font-weight: 600;
-    color: ${(props) => props.theme.gray_1};
+    color: var(--darkgray-from-grayscale);
   }
 `;
 
 const StyledCalendar = styled(Calendar)``;
 
-/* 출석한 날짜에 점 표시 스타일 */
-export const StyledDot = styled.div`
-  background-color: ${(props) => props.theme.br_2};
-  border-radius: 50%;
-  width: 0.3rem;
-  height: 0.3rem;
+// 체크박스 이미지 스타일 설정
+const StyledCheckbox = styled(Image)`
   position: absolute;
   top: 60%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%); 
 `;

--- a/harudoyak/src/pages/index.tsx
+++ b/harudoyak/src/pages/index.tsx
@@ -2,19 +2,29 @@ import React from "react";
 import MonthlyCalendar from "../components/home/MonthlyCalendar";
 import styled from "styled-components";
 import Root from "./../style/Root";
+import LoginButton from '../components/home/HomeLoginButton';
 
 const Home: React.FC = () => {
   return (
     <Root>
-      <Heading1>하루도약을 시작하기 위해<br></br>마이페이지를 클릭해주세요</Heading1>
+      <Heading2>하루도약 시작하기</Heading2>
+      <StyledLogin />
       <MonthlyCalendar></MonthlyCalendar>
     </Root>
   );
 };
 
-const Heading1 = styled.h1`
+const Heading2 = styled.h2`
   font-size: 1.44rem;
   color: var(--main-green);
+  padding: 3% 5%;
+  text-align: center;
+`;
+
+const StyledLogin = styled(LoginButton)`
+  display: flex;
+  position: absolute;
+  left: 50%;
 `;
 
 export default Home;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [X] 기능 추가 (Feat)
- [ ] 버그 / 에러 수정 (Fix)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] 코드 구조 등 리팩토링 (Refactor)
- [X] 스타일 추가 및 수정 (Style)
- [ ] 문서 관련 (Docs)
- [ ] 기능 삭제 (Delete)

## 📝작업 내용
- 기록 작성된 날짜에 체크박스 추가 테스트(현재는 더미 데이터 -> API 데이터로 교체 예정) 
- 로그인 이전 화면에 로그인 버튼 추가

## 스크린샷(선택)
![image](https://github.com/user-attachments/assets/36f264de-cbbd-4525-988a-626b366e0cb1)

## 💬리뷰 요구사항 / 질문(선택)
- 월간 달력에서 날짜 클릭시 조건에 따라 기록 작성 페이지 이동 or 기록 확인 페이지 이동 or 모달 팝업으로 각각 달라지는데 이때 기록 작성 페이지나 기록 확인 페이지로 이동 시 라우터에 필요한 회원ID 정보 같은 데이터를 어떤 방식으로 넘겨줘야 할까요?
- 도약기록 작성일(creationDate)의 형식 관련 -> YYYY-MM-DD 00:00:00 처럼 시간도 필요할까요? 아니면 YYYY-MM-DD 처럼 날짜만 있으면 될까요?

## TODO(선택, 다음 작업 예고)
- 로그인 이후 화면 추가
- 모달 컴포넌트 추가
- 날짜 클릭 시 기록 작성 or 기록 확인 페이지 이동 or 모달 팝업 구현 완료
