### PR TITLE
zustandphoto

### DIFF
--- a/harudoyak/src/components/community/CancelNextBar.tsx
+++ b/harudoyak/src/components/community/CancelNextBar.tsx
@@ -1,33 +1,50 @@
+// components/community/CancelNextBar.tsx
 import React from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
+import useCommunityStore from '../../store/useCommunityStore';
 
 const CancelNextBarContainer = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    height: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 20px;
 `;
 
 const Button = styled.button`
-    color: #000;
-    font-family: Inter;
-    font-size: 13px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 21px; /* 161.538% */
-    letter-spacing: -0.33px;
+  color: #000;
+  font-family: Inter;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 21px;
+  letter-spacing: -0.33px;
 `;
 
 export const CancelNextBar: React.FC = () => {
-    const router = useRouter();
+  const router = useRouter();
+  const { clearTemporaryData, selectedPhoto } = useCommunityStore();
 
-    return (
-        <CancelNextBarContainer>
-            <Button onClick={() => router.push('/community')}>취소</Button>
-            <Button onClick={() => router.push('/community/select-comment')}>다음</Button>
-            
-        </CancelNextBarContainer>
-    );
+  const handleCancel = () => {
+    if (confirm("정말 취소하시겠습니까? 작성하신 내용은 저장되지 않습니다.")) {
+      clearTemporaryData();
+      router.push('/community');
+    }
+  };
+
+  const handleNext = () => {
+    if (!selectedPhoto) {
+      alert('사진을 선택해주세요!');
+    } else {
+      router.push('/community/select-comment');
+    }
+  };
+
+  return (
+    <CancelNextBarContainer>
+      <Button onClick={handleCancel}>취소</Button>
+      <Button onClick={handleNext}>다음</Button>
+    </CancelNextBarContainer>
+  );
 };

--- a/harudoyak/src/components/community/MainHeader.tsx
+++ b/harudoyak/src/components/community/MainHeader.tsx
@@ -1,6 +1,7 @@
 // components/community/MainHeader.tsx
 import React from 'react';
 import styled from 'styled-components';
+import { useRouter } from 'next/router';
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -13,12 +14,19 @@ const HeaderWrapper = styled.header`
 const Title = styled.h1`
   font-size: 1.5rem;
   color: white;
+  cursor: pointer; /* 클릭 가능하도록 커서 변경 */
 `;
 
 const MainHeader: React.FC = () => {
+  const router = useRouter();
+
+  const handleLogoClick = () => {
+    router.push('/community#top'); // 최상단 게시글로 이동
+  };
+
   return (
     <HeaderWrapper>
-      <Title>서로도약</Title>
+      <Title onClick={handleLogoClick}>서로도약</Title>
     </HeaderWrapper>
   );
 };

--- a/harudoyak/src/components/community/MainPhoto.tsx
+++ b/harudoyak/src/components/community/MainPhoto.tsx
@@ -1,3 +1,4 @@
+// MainPhoto.tsx
 import React from 'react';
 import styled from 'styled-components';
 
@@ -26,7 +27,7 @@ export const MainPhoto: React.FC<MainPhotoProps> = ({ selectedPhoto }) => {
             {selectedPhoto ? (
                 <Photo src={selectedPhoto} alt="Selected" />
             ) : (
-                <p>가장 최근에 찍은 사진이 여기에 표시됩니다.</p>
+                <p>아래의 첨부된 사진에서 선택하면 표시됩니다.</p>
             )}
         </MainPhotoContainer>
     );

--- a/harudoyak/src/components/community/PhotoGrid.tsx
+++ b/harudoyak/src/components/community/PhotoGrid.tsx
@@ -1,6 +1,8 @@
+// PhotoGrid.tsx
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import Thumbnail from './Thumbnail'; // Thumbnail 컴포넌트를 import 합니다.
+import Thumbnail from './Thumbnail';
+import useCommunityStore from '../../store/useCommunityStore';
 
 const PhotoGridContainer = styled.div`
     position: relative;
@@ -37,8 +39,8 @@ const SelectBox = styled.div`
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(3, 1fr); // 한 줄에 3개의 그리드
-    grid-auto-rows: minmax(100px, auto); // 각 그리드의 높이 설정
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: minmax(100px, auto);
     gap: 10px;
     padding-top: 30px;
 `;
@@ -62,23 +64,19 @@ interface PhotoGridProps {
 }
 
 export const PhotoGrid: React.FC<PhotoGridProps> = ({ setSelectedPhoto }) => {
-    const [photos, setPhotos] = useState<string[]>([]);
-    const [selectedPhoto, setSelectedPhotoState] = useState<string | null>(null);
+    const { photos, addPhotos, setSelectedPhoto: setCommunitySelectedPhoto } = useCommunityStore();
 
     const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const files = event.target.files;
         if (files) {
             const newPhotos = Array.from(files).map(file => URL.createObjectURL(file));
-            setPhotos(prevPhotos => {
-                const uniquePhotos = newPhotos.filter(photo => !prevPhotos.includes(photo));
-                return [...prevPhotos, ...uniquePhotos];
-            });
+            addPhotos(newPhotos);
         }
     };
 
     const handlePhotoClick = (photo: string) => {
         setSelectedPhoto(photo);
-        setSelectedPhotoState(photo);
+        setCommunitySelectedPhoto(photo);
     };
 
     return (
@@ -98,7 +96,7 @@ export const PhotoGrid: React.FC<PhotoGridProps> = ({ setSelectedPhoto }) => {
                         key={index}
                         src={photo}
                         alt={`Photo ${index + 1}`}
-                        isSelected={selectedPhoto === photo}
+                        isSelected={photos.includes(photo)}
                         onClick={() => handlePhotoClick(photo)}
                     />
                 ))}

--- a/harudoyak/src/components/community/ShareButton.tsx
+++ b/harudoyak/src/components/community/ShareButton.tsx
@@ -1,3 +1,4 @@
+// ShareButton.tsx
 import React from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
@@ -7,12 +8,12 @@ const ButtonContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 0; /* Ensure no margin is affecting the centering */
+    margin: 0;
 `;
 
 const Button = styled.button`
     width: 90%;
-    max-width: 300px; /* 버튼의 최대 너비 설정 */
+    max-width: 300px;
     height: 40px;
     font-size: 16px;
     color: white;
@@ -20,8 +21,8 @@ const Button = styled.button`
     border: none;
     border-radius: 24px;
     cursor: pointer;
-    display: inline-flex; /* 아이콘과 텍스트를 나란히 배치 */
-    align-items: center; /* 아이콘과 텍스트를 수직으로 중앙 정렬 */
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
     text-align: center;
 `;
@@ -32,12 +33,16 @@ const IconWrapper = styled.div`
     margin-right: 8px;
 `;
 
-export const ShareButton: React.FC = () => {
+interface ShareButtonProps {
+    onClick?: () => void;
+}
+
+const ShareButton: React.FC<ShareButtonProps> = ({ onClick }) => {
     const router = useRouter();
 
     const handleShare = () => {
-        // community 메인 페이지로 라우트
-        router.push('/community');
+        if (onClick) onClick();
+        router.push('/community'); // communityhome으로 라우팅
     };
 
     return (
@@ -51,3 +56,5 @@ export const ShareButton: React.FC = () => {
         </ButtonContainer>
     );
 };
+
+export default ShareButton;

--- a/harudoyak/src/pages/community/index.tsx
+++ b/harudoyak/src/pages/community/index.tsx
@@ -1,36 +1,53 @@
-import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
+// index.tsx (CommunityHome)
+import React from 'react';
 import styled from 'styled-components';
 import NavigationBar from '@/src/components/common/navigationbar/NavigationBar';
 import MainHeader from '../../components/community/MainHeader';
 import { MainPhoto } from '../../components/community/MainPhoto';
-import { CommentInput } from '../../components/community/CommentInput';
 import WriteButton from '../../components/community/WriteButton';
 import Root from '../../style/Root';
+import useCommunityStore from '../../store/useCommunityStore';
 
 const CommunityHome: React.FC = () => {
-  const [comment, setComment] = useState("");
-  const [selectedPhoto, setSelectedPhoto] = useState<string | null>(null);
-  const [posts, setPosts] = useState<any[]>([]); // 기존 게시글 목록
-  const router = useRouter();
+    const { posts } = useCommunityStore();
 
-  useEffect(() => {
-    const { newPost } = router.query;
-    if (newPost) {
-      const parsedPost = Array.isArray(newPost) ? newPost[0] : newPost;
-      setPosts([...posts, JSON.parse(parsedPost)]); // 새로운 게시글 추가
-    }
-  }, [router.query]);
-
-  return (
-    <Root>
-      <MainHeader />
-      <MainPhoto selectedPhoto={selectedPhoto} />
-      <CommentInput comment={comment} setComment={setComment} />
-      <WriteButton />
-      <NavigationBar />
-    </Root>
-  );
+    return (
+        <Root>
+            <MainHeader />
+            <PostList>
+                {posts.map((post, index) => (
+                    <Post key={index}>
+                        <MainPhoto selectedPhoto={post.photo} />
+                        <Comment>{post.comment}</Comment>
+                    </Post>
+                ))}
+            </PostList>
+            <WriteButton />
+            <NavigationBar />
+        </Root>
+    );
 };
 
 export default CommunityHome;
+
+const PostList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  overflow-y: auto;
+`;
+
+const Post = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 8px;
+`;
+
+const Comment = styled.p`
+  margin-top: 8px;
+  font-size: 1rem;
+  color: #333;
+`;

--- a/harudoyak/src/pages/community/select-comment.tsx
+++ b/harudoyak/src/pages/community/select-comment.tsx
@@ -1,28 +1,32 @@
+// SelectCommentPage.tsx
 import React, { useState } from 'react';
 import { Header } from '../../components/community/Header';
 import { CancelBar } from '../../components/community/CancelBar';
 import { MainPhoto } from '../../components/community/MainPhoto';
 import { CommentInput } from '../../components/community/CommentInput';
 import { ExampleTextBox } from '../../components/community/ExampleTextBox';
-import { ShareButton } from '../../components/community/ShareButton';
+import ShareButton from '../../components/community/ShareButton';
 import styled from 'styled-components';
 import Root from '../../style/Root';
+import useCommunityStore from '../../store/useCommunityStore';
 
 const SelectCommentPage: React.FC = () => {
-    const [comment, setComment] = useState("");
-    const [selectedPhoto, setSelectedPhoto] = useState<string | null>(null); // 선택한 사진의 URL 또는 경로
+    const { selectedPhoto, comment, setComment, addPost } = useCommunityStore();
+
+    const handleShare = () => {
+        addPost();
+        alert('게시글이 저장되었습니다!');
+    };
 
     return (
         <Root>
             <Header />
             <Heading1></Heading1>
             <CancelBar />
-            <MainPhoto selectedPhoto={selectedPhoto} /> {/* selectedPhoto 속성 추가 */}
-            <Heading3></Heading3>
+            <MainPhoto selectedPhoto={selectedPhoto} />
             <CommentInput comment={comment} setComment={setComment} />
-            <Heading2></Heading2>
             <ExampleTextBox />
-            <ShareButton />
+            <ShareButton onClick={handleShare} />
         </Root>
     );
 };
@@ -33,24 +37,4 @@ const Heading1 = styled.h1`
   font-size: 1.44rem;
   color: var(--main-green);
   margin-bottom: 10px;
-`;
-const Heading2 = styled.h2`
-  font-size: 1.56rem;
-  color: var(--sub-green2);
-  margin-bottom: 2px;
-  margin-top: 2px;
-`;
-
-const Heading3 = styled.h3`
-  font-size: 1.56rem;
-  color: var(--sub-green2);
-  margin-bottom: 2px;
-  margin-top: 2px;
-`;
-
-const Heading4 = styled.h4`
-  font-size: 1.56rem;
-  color: var(--sub-green2);
-  margin-bottom: 12px;
-  margin-top: 14px;
 `;

--- a/harudoyak/src/pages/community/select-picture.tsx
+++ b/harudoyak/src/pages/community/select-picture.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+// SelectPicture.tsx
+import React from 'react';
 import styled from 'styled-components';
 import { Header } from '../../components/community/Header';
 import { CancelNextBar } from '../../components/community/CancelNextBar';
 import { PhotoGrid } from '../../components/community/PhotoGrid';
 import { MainPhoto } from '../../components/community/MainPhoto';
 import Root from "../../style/Root";
+import useCommunityStore from '../../store/useCommunityStore';
 
 const SelectPicture: React.FC = () => {
-    const [selectedPhoto, setSelectedPhoto] = useState<string | null>(null);
+    const { selectedPhoto, setSelectedPhoto } = useCommunityStore();
 
     return (
         <Root>

--- a/harudoyak/src/store/useCommunityStore.ts
+++ b/harudoyak/src/store/useCommunityStore.ts
@@ -1,0 +1,50 @@
+// store/useCommunityStore.ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface CommunityState {
+    selectedPhoto: string | null;
+    comment: string;
+    posts: Array<{ photo: string | null; comment: string }>;
+    photos: string[]; // PhotoGrid의 사진들을 관리할 배열
+    setSelectedPhoto: (photo: string | null) => void;
+    setComment: (comment: string) => void;
+    addPost: () => void;
+    addPhotos: (newPhotos: string[]) => void;
+    clearPhotos: () => void;
+    clearTemporaryData: () => void;
+}
+
+const useCommunityStore = create<CommunityState>()(
+    persist(
+        (set) => ({
+            selectedPhoto: null,
+            comment: "",
+            posts: [],
+            photos: [],
+            setSelectedPhoto: (photo) => set({ selectedPhoto: photo }),
+            setComment: (comment) => set({ comment }),
+            addPost: () => set((state) => ({
+                posts: [
+                    { photo: state.selectedPhoto, comment: state.comment },
+                    ...state.posts,
+                ],
+                selectedPhoto: null,
+                comment: "",
+            })),
+            addPhotos: (newPhotos) => set((state) => ({
+                photos: [...state.photos, ...newPhotos],
+            })),
+            clearPhotos: () => set({ photos: [] }),
+            clearTemporaryData: () => set({ selectedPhoto: null, comment: "" }),
+        }),
+        {
+            name: 'communityData',
+            partialize: (state) => ({
+                posts: state.posts,
+            }),
+        }
+    )
+);
+
+export default useCommunityStore;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가 (Feat)
- [ ] 버그 / 에러 수정 (Fix)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] 코드 구조 등 리팩토링 (Refactor)
- [ ] 스타일 추가 및 수정 (Style)
- [ ] 문서 관련 (Docs)
- [ ] 기능 삭제 (Delete)


## 📝작업 내용
00 src/store/useCommunityStore.ts에 서로도약 관련된 zustand를 추가하였습니다.
00 photogrid, commentinput,mainphoto가 게시글 작성 내에서 화면이 바뀌더라도 유지되도록 구현했습니다. 특히 photogrid는 게시글 작성창 밖으로 나가더라도(취소) 다시 돌아왔을 때 사용자편의를 위해 유지되도록 했습니다.
00 취소, 다음,  공유하세요! 버튼을 눌렀을 시 각각 '정말 취소하시겠습니까?...', '사진을 선택해주세요', '게시글이 저장되었습니다'의 alert가 뜨도록 했습니다.
00 게시글 메인페이지에서 로컬의 사용자가 작성한 게시글이 상단에 뜨는 형태로 구현했습니다. 


## 스크린샷(선택)
<취소시>
![스크린샷 2024-11-02 225618](https://github.com/user-attachments/assets/d427be8a-f4e1-4e1f-9fea-fb9dd3ab0362)


<사진 선택안햇을 시>
![스크린샷 2024-11-02 230038](https://github.com/user-attachments/assets/4221b139-0153-4300-ac34-6467f95e783e)


<공유하세요! 눌렀을시>
![스크린샷 2024-11-02 225548](https://github.com/user-attachments/assets/d106eb26-af54-4766-9f09-57dd701bf9bf)


<게시글 작성후 반영된 메인>
![스크린샷 2024-11-02 235447](https://github.com/user-attachments/assets/15c67eec-d0bc-4c72-8be7-ef8534ff00e7)



## 💬리뷰 요구사항 / 질문(선택)
zustand로 일단 로컬의 사용자가 이용할 때의 ux/ui를 고려해서 작업하고 있는데 나중에 백엔드 서버와 연동함에 있어서 큰 문제가 없는지 궁금합니다.



## TODO(선택, 다음 작업 예고)
community 메인에서의
댓글 작성자 이름, #도약목표, 도약버튼 및 댓글 작성을 zustand를 이용하여 구현해보겠습니다.