### PR TITLE
feat: WritingPage에서 작성한 텍스트 받아오기

### DIFF
--- a/harudoyak/package-lock.json
+++ b/harudoyak/package-lock.json
@@ -15,6 +15,7 @@
         "moment": "^2.30.1",
         "next": "^14.2.16",
         "next-svgr": "^0.0.2",
+        "openai": "^4.71.0",
         "react": "^18.3.1",
         "react-calendar": "^5.1.0",
         "react-dom": "^18.3.1",
@@ -2438,6 +2439,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2486,13 +2495,26 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+    },
     "node_modules/@types/node": {
       "version": "20.16.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
       "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -2766,6 +2788,17 @@
         "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -2785,6 +2818,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -4692,6 +4736,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4888,6 +4940,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
       }
     },
     "node_modules/fs.realpath": {
@@ -5237,6 +5306,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -7416,6 +7493,43 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -7586,6 +7700,44 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openai": {
+      "version": "4.71.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.71.0.tgz",
+      "integrity": "sha512-jeJ7+6cZvj+ZbIsbX/Ag8+pug2+vjKbrD/v3Hwp6uv3KZyWjSkZa5MdUshzpNC3jsFzakfbUhEEFQXsKWNgm/g==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.64",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
+      "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -8874,6 +9026,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9047,8 +9204,7 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -9272,6 +9428,28 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/harudoyak/package.json
+++ b/harudoyak/package.json
@@ -17,6 +17,7 @@
     "moment": "^2.30.1",
     "next": "^14.2.16",
     "next-svgr": "^0.0.2",
+    "openai": "^4.71.0",
     "react": "^18.3.1",
     "react-calendar": "^5.1.0",
     "react-dom": "^18.3.1",

--- a/harudoyak/src/components/Modal.tsx
+++ b/harudoyak/src/components/Modal.tsx
@@ -1,0 +1,12 @@
+// 컴포넌트 이름: Modal.tsx
+// 컴포넌트 설명: 공통 모달
+// 주 사용처: 모달을 띄우는 모든 곳에 사용 가능 
+
+// Dev Log
+// 최초 작성일/작성자: 2024.11.02./루이
+
+type Props = {
+  title?: string;
+  alert?: string;
+  coin?: number | string;
+}

--- a/harudoyak/src/components/common/Header/CenterTextHeader.tsx
+++ b/harudoyak/src/components/common/Header/CenterTextHeader.tsx
@@ -15,14 +15,18 @@ import iconX from "@/public/assets/common/icon_X.svg";
 import UndoXButton from "../../buttons/UndoXButton";
 import CenterTextHeaderBtn from "./CenterTextHeaderBtn";
 
-const CenterTextHeader: React.FC = () => {
+interface TextCenterHeaderProps {
+  text: string;
+}
+
+const CenterTextHeader: React.FC<TextCenterHeaderProps> = ({ text }) => {
   return (
     <>
       <HeaderWrapper>
         <UndoXButton icon={iconX} />
         <Heading3>도약기록 쓰기</Heading3>
         <Link href="/grow-up-record">
-          <CenterTextHeaderBtn />
+          <CenterTextHeaderBtn text={text} />
         </Link>
         {/* TIP: href 속성에 라우팅하고 싶은 페이지 링크 작성*/}
       </HeaderWrapper>

--- a/harudoyak/src/components/common/Header/CenterTextHeaderBtn.tsx
+++ b/harudoyak/src/components/common/Header/CenterTextHeaderBtn.tsx
@@ -1,19 +1,30 @@
 // 컴포넌트 이름: CenterTextHeaderBtn
-// 컴포넌트 설명: CenterTextHeader 우측 가장자리에 들어가는 작은 '완료' 버튼 
+// 컴포넌트 설명: CenterTextHeader 우측 가장자리에 들어가는 작은 '완료' 버튼
 // 주 사용처: '도약기록 쓰기', 회원가입 flow 등에서 활용 가능
 // 저장 위치: src/components/commom/Header/CenterTextHeaderBtn.tsx
 
 // Dev Log
 // 최초 작성일/작성자: 2024.10.25./루이
-// 수정일/작성자: 
+// 수정일/작성자:
 
 import React from "react";
 import styled from "styled-components";
 
-const CenterTextHeaderBtn: React.FC = () => {
+interface CenterTextHeaderBtnProps {
+  text: string;
+}
+
+const CenterTextHeaderBtn: React.FC<CenterTextHeaderBtnProps> = ({ text }) => {
+  const handleSubmit = () => {
+    
+
+    
+    console.log("Client to Server: ", text);
+  };
+
   return (
     <>
-      <Button>완료</Button>
+      <Button onClick={handleSubmit}>완료</Button>
     </>
   );
 };

--- a/harudoyak/src/components/grow-up-record/DoneModal.tsx
+++ b/harudoyak/src/components/grow-up-record/DoneModal.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+interface DoneModalProps {
+  clickModal: () => void;
+}
+
+const DoneModal: React.FC<DoneModalProps> = ({ clickModal }) => {
+  
+  
+
+  return <ModalBox></ModalBox>;
+};
+
+// styled-components
+const ModalBox = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/harudoyak/src/components/grow-up-record/ImageUploadButton.tsx
+++ b/harudoyak/src/components/grow-up-record/ImageUploadButton.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 interface ImageUploadButtonProps {
   src: string;
   children: React.ReactNode;
-  setPreviewUrl: (url: string) => void; // setPreviewUrl prop 추가
+  setPreviewUrl: (url: string) => void; 
 }
 
 const ImageUploadButton: React.FC<ImageUploadButtonProps> = ({

--- a/harudoyak/src/context/PostDataContext.tsx
+++ b/harudoyak/src/context/PostDataContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext } from "react";
+import usePostData, { PostData } from "../hooks/usePostData";
+
+interface PostDataContextType extends PostData {
+  updateText: (newText: string) => void;
+  updateEmotion: (newEmotion: number) => void;
+  updateImage: (newImage: File | null) => void;
+  updateTags: (newTags: string[]) => void;
+}
+
+const PostDataContext = createContext<PostDataContextType | undefined>(
+  undefined,
+);
+
+export const PostDataProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const {
+    text,
+    emotion,
+    image,
+    tags,
+    updateText,
+    updateEmotion,
+    updateImage,
+    updateTags,
+  } = usePostData();
+
+  return (
+    <PostDataContext.Provider
+      value={{
+        text,
+        emotion,
+        image,
+        tags,
+        updateText,
+        updateEmotion,
+        updateImage,
+        updateTags,
+      }}
+    >
+      {children}
+    </PostDataContext.Provider>
+  );
+};
+
+export const usePostDataContext = () => {
+  const context = useContext(PostDataContext);
+  if (!context) {
+    throw new Error(
+      "usePostDataContext must be used within a PostDataProvider",
+    );
+  }
+  return context;
+};

--- a/harudoyak/src/pages/_app.tsx
+++ b/harudoyak/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import type { AppProps } from "next/app";
 import GlobalStyle from "../style/GlobalStyle";
 import Layout from "../components/Layout";
+import {PostDataProvider} from '../context/PostDataContext';
 
 // 새로고침마다 토큰 상태 확인 및 갱신 하기위해 useEffect에 해당 함수 설정해야함
 import { checkAndRefreshToken } from "../store/tokenService";
@@ -16,7 +17,9 @@ function App({ Component, pageProps }: AppProps) {
     <>
       <GlobalStyle />
       <Layout>
-        <Component {...pageProps} />
+        <PostDataProvider>
+          <Component {...pageProps} />
+        </PostDataProvider>
       </Layout>
     </>
   );

--- a/harudoyak/src/pages/grow-up-record/index.tsx
+++ b/harudoyak/src/pages/grow-up-record/index.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import Image from "next/image";
+import { usePostDataContext } from "@/src/context/PostDataContext";
 
 import Root from "../../style/Root";
 import UndoXButton from "../../components/buttons/UndoXButton";
@@ -17,19 +18,11 @@ import iconTooltip from "../../../public/assets/common/icon_tooltip.svg";
 import iconReload from "../../../public/assets/common/icon_reload.svg";
 import iconX from "../../../public/assets/common/icon_X.svg";
 import SubmitButton from "../../components/grow-up-record/SubmitButton";
-
+//import DoneModal from '../../components/grow-up-record/DoneModal';
 
 const GrowUpRecordHome: React.FC = () => {
-  const {
-    text,
-    image,
-    emotion,
-    tags,
-    updateText,
-    updateImage,
-    updateEmotion,
-    updateTags,
-  } = usePostData();
+  const { text, image, emotion, tags, updateEmotion, updateTags } =
+    usePostDataContext();
 
   const [isTooltipOpened, setIsTooltipOpened] = useState<boolean>(false);
   const handleTooltip = (): void => {
@@ -37,6 +30,9 @@ const GrowUpRecordHome: React.FC = () => {
   };
 
   const mocktags = ["WAS", "Github", "가이드북", "비즈니스 매너"];
+
+  const [showModal, setShowModal] = useState(false);
+  const clickModal = () => setShowModal(!showModal);
 
   return (
     <Root>
@@ -52,7 +48,7 @@ const GrowUpRecordHome: React.FC = () => {
 
       <FlexWrapper>
         <Heading2 style={{ marginBottom: "8px" }}>오늘의 도약 기록</Heading2>
-        {text ? <></> : <EditButton />}
+        {text ? <EditButton /> : <></>}
       </FlexWrapper>
       <Link href="/writing-page">
         <TextEntryButton>
@@ -85,7 +81,8 @@ const GrowUpRecordHome: React.FC = () => {
           style={{ transform: "translateY(-25px)" }}
         />
       </FlexWrapper>
-      <SubmitButton data={{text, emotion, image: null, tags}}>도약기록 남기기</SubmitButton>
+      {/*<SubmitButton data={{text, emotion, image: null, tags}} onClick={clickModal} size={60}>도약기록 남기기</SubmitButton>
+      {/*{showModal && <DoneModal clickModal={clickModal}/>}*/}
     </Root>
   );
 };

--- a/harudoyak/src/pages/writing-page/index.tsx
+++ b/harudoyak/src/pages/writing-page/index.tsx
@@ -1,28 +1,22 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import styled from "styled-components";
 import ReactMarkdown from "react-markdown";
+import { usePostDataContext } from "@/src/context/PostDataContext";
 import TextCenterHeader from "../../components/common/Header/CenterTextHeader";
 
-//import { useForm } from "react-hook-form";
-//import Link from "next/link";
-
-interface WritingPageProps {
-  text: string;
-  updateText: (newText: string) => void;
-}
-
-const WritingPage: React.FC<WritingPageProps> = ({ text, updateText }) => {
+const WritingPage: React.FC = () => {
+  const {text, updateText} = usePostDataContext();
+ //const textareaRef = useRef<HTMLTextAreaElement>(null);
   const infoMarkdown = `도약기록에 다음과 같은 것들을 적어보세요. \n
 - **성취**: '오늘의 나는 무엇을 잘했는지'  
 - **개선**: '오늘의 나는 어떤 문제를 겪었는지, 앞으로 어떻게 해결할 것인지'  
 - **학습**: '오늘의 일에서 나는 어떤 것을 배웠는지'   \n
 위 세 가지가 오늘도 한 단계 도약한 나 자신을 발견하도록 이끌어 줄 거예요 :)
 `;
-  console.log(text);
 
   return (
     <>
-      <TextCenterHeader />
+      <TextCenterHeader text={text}/>
       <Wrapper>
         <Textarea
           value={text}
@@ -49,6 +43,7 @@ const Textarea = styled.textarea`
   all: unset;
   white-space: pre-line;
   width: 100%;
+  height: 300px;
   background: var(--background);
   border: none;
   color: var(--gray-for-grayscale);


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가 (Feat)

## 📝작업 내용
- Context를 추가하여, WritingPage에서 작성한 text를 기존 작성 페이지에서도 확인할 수 있게 구현(영상 참고)
- 처음 도약기록 작성창 들어가면, '수정'버튼 보이지 않고, WritingPage에서 텍스트 한 번 이상 작성한 후에 '수정' 버튼이 나타날 수 있도록 구현

## 스크린샷(선택)

https://github.com/user-attachments/assets/116dc4a7-fdcd-4b49-a1e1-dffb7709f0bd




## 💬리뷰 요구사항 / 질문(선택)
WritingPage 내 textarea의 크기를,
1. 텍스트 길이에 따라 자동으로 늘어나게 할 지, 아니면 
2. 높이를 고정적으로 주어서 작성하는 텍스트 글자수에 제한을 둘 지 고민입니다. 
한번씩 의견 말씀해 주시면 감사하겠습니다! 


## TODO(선택, 다음 작업 예고)
- [ ] **Open AI keyword API 붙여보기**
- [ ] WritingPage에서 작성한 엔터가 grow-up-record/index.tsx 페이지에서는 반영이 안 되는 문제 해결하기 (아마도 markdown 문법 때문에 그런 것 같습니다 )
- [ ] 두 번째 부터는 textentryButton은 비활성화되어서 이 버튼으로는 수정하지 못하고, '수정'버튼을 통해서만 수정할 수 있도록 바꾸기