### PR TITLE
fix: API 연동 및 라우터 쿼리 수정

### DIFF
--- a/harudoyak/src/apis/logsApi.ts
+++ b/harudoyak/src/apis/logsApi.ts
@@ -1,4 +1,5 @@
 // 도약기록 관련 api 모음
+import axios from "axios";
 import axiosInstance from "./axiosInstance";
 import { useUserStore } from "../store/useUserStore";
 import { uploadToS3 } from "./uploadToS3";
@@ -10,8 +11,28 @@ export type RecordItem = {
 
 export const fetchRecordList = async (): Promise<RecordItem[]> => {
   const { memberId } = useUserStore.getState();
-  const response = await axiosInstance.get(`logs/list/${memberId}`);
-  return response.data;
+
+  // console.log("memberId:", memberId); // memberId가 올바른지 확인
+  if (!memberId) {
+      throw new Error("유효하지 않은 memberId입니다.");
+  }
+
+  try {
+    const response = await axiosInstance.get(`logs/list/${memberId}`);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      // AxiosError인 경우, 추가 정보 출력
+      console.error("Axios Error:", error.toJSON());
+      console.error("Response Status:", error.response?.status);
+      console.error("Response Data:", error.response?.data);
+    } else {
+      // 일반적인 오류인 경우, 기본 에러 메시지 출력
+      const generalError = error as Error;
+      console.error("Error:", generalError.message);
+    }
+    throw Error; // 필요 시 에러를 다시 던짐
+  }
 };
 
 // 도약기록 쓰기 API (image 파일로 받아서, 내부에서 uploadToS3 함수 호출(서버에 url로 전송))

--- a/harudoyak/src/components/home/MonthlyCalendar.tsx
+++ b/harudoyak/src/components/home/MonthlyCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import styled from "styled-components";
@@ -17,36 +17,29 @@ type Value = ValuePiece | [ValuePiece, ValuePiece];
 const MonthlyCalendar: React.FC = () => {
   const today: Date = new Date(); // 현재 날짜 및 시간
   const [date, setDate] = useState<Value>(today);
-  // 기록 작성된 일자 (테스트용으로 날짜 임시 지정)
-  const recordOn = [
-    "2022-12-25",
-    "2023-09-15",
-    "2024-09-15",
-    "2024-10-15",
-    "2024-10-20",
-    "2024-10-29",
-    "2024-10-31",
-  ];
 
-  // api에서 response 받아와서 recordDayList 로 만들어줄 예정
   const [recordDayList, setRecordDayList] = useState<string[]>([]);
   const { memberId } = useUserStore();
-  const fetchList = async () => {
-    try {
-      const response = await fetchRecordList();
-      // creationDate 값들만 추출하여 배열로 만들어줌
-      // response.data.map(item => item.creationDate)
-      setRecordDayList(response.map((item: RecordItem) => item.creationDate));
-      // console.log(recordDayList);
-    } catch (error) {
-      console.error("Failed to fetch record list:", error);
-      throw error;
-    }
-  };
 
-  if (memberId) {
-    fetchList();
-  }
+
+  useEffect(() => {
+    const fetchList = async () => {
+      try {
+        const response = await fetchRecordList();
+        // creationDate 값들만 추출하여 recordDayList 배열에 값 업데이트
+        setRecordDayList(response.map((item: RecordItem) => item.creationDate.substring(0, 10)));
+      } catch (error) {
+        console.error("Failed to fetch record list:", error);
+        throw error;
+      }
+    };
+
+    if (memberId) {
+      fetchList();
+    }
+  }, [memberId]);
+
+  // console.log(recordDayList);
 
   const formatDate = (date: Date) =>
     date
@@ -72,14 +65,20 @@ const MonthlyCalendar: React.FC = () => {
     const formattedToday = formatDate(today);
 
     switch (true) {
-      // 로그인이 안되어 있을경우 ,
+      // 로그인이 안 한 상태 - 경고창 팝업
       case memberId === null:
         alert("로그인을 먼저 해주세요");
         break;
 
       // 작성된 기록 있음 - 일간 기록 확인 페이지로 이동
       case recordDayList.includes(formattedValue):
-        router.push("/grow-check");
+        router.push({
+          pathname: "/grow-check",
+          query: {
+            dayToSelect: formattedValue
+          }},
+          `/grow-check/daily`, // query masking
+        );
         break;
 
       // 작성된 기록 없음 && 클릭한 날짜가 오늘 - 기록 작성 페이지로 이동
@@ -114,12 +113,12 @@ const MonthlyCalendar: React.FC = () => {
         prev2Label={null} // -1년 & -10년 이동 버튼 숨기기
         minDetail="year" // 10년단위 년도 숨기기
         onClickDay={(value: Date) => {
-          console.log("Selected day:", value); // 선택한 날짜 출력
+          // console.log("Selected day:", value); // 선택한 날짜 출력
           handleDateClick(value); // 선택한 날짜에 대한 추가 처리
         }}
         tileContent={({ date }) => {
           const html = [];
-          if (recordOn.find((x) => x === moment(date).format("YYYY-MM-DD"))) {
+          if (recordDayList.find((x) => x === moment(date).format("YYYY-MM-DD"))) {
             html.push(
               <StyledCheckbox
                 className="checkbox"
@@ -134,7 +133,7 @@ const MonthlyCalendar: React.FC = () => {
       />
       {open && (
         <Modal open={open} onClose={() => setOpen(false)}>
-          <div>선택한 날짜에 작성된 기록이 없습니다</div>
+          <div>선택한 날짜에<br></br>작성된 기록이 없습니다</div>
         </Modal>
       )}
     </StyledCalendarWrapper>

--- a/harudoyak/src/pages/grow-check/index.tsx
+++ b/harudoyak/src/pages/grow-check/index.tsx
@@ -11,6 +11,7 @@ import MonthFeel from "@/src/components/growcheck/MonthFeel";
 // todo: 알람에서 주/월, 당일 피드백에 대해서 클릭을 하면 props로 해당하는 기간을 주고 그에따라 변수를 조정해
 //  도약 기록 페이지 일/주/월 에따른 페이지 모습이 나오게 해야함
 import { addDays, startOfWeek } from "date-fns";
+import { useRouter } from "next/router";
 
 const GrowCheckHome: React.FC = () => {
   const currentMonth = new Date().getMonth();
@@ -26,11 +27,16 @@ const GrowCheckHome: React.FC = () => {
   const [selectedDay, setSelectedDay] = useState<Date | null>(null); // weekly에서 선택한 날
 
   // router.query 이용해서 들어오면 가능함
+  const router = useRouter();
   useEffect(() => {
-    const dayToSelect = addDays(new Date(), 0);
+    // MonthlyCalendar의 router.query에서 dayToSelect를 가져옴
+    const dayToSelect = router.query.dayToSelect 
+    ? new Date(router.query.dayToSelect as string)
+    : addDays(new Date(), 0);
+
     setSelectedDay(dayToSelect);
     setSelectedMonth(dayToSelect.getMonth());
-  }, []);
+  }, [router.query.dayToSelect]); // dayToSelect 변경 시 effect 실행
 
   useEffect(() => {
     if (selectedMonth === currentMonth) {


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [ ] 기능 추가 (Feat)
- [X] 버그 / 에러 수정 (Fix)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] 코드 구조 등 리팩토링 (Refactor)
- [ ] 스타일 추가 및 수정 (Style)
- [ ] 문서 관련 (Docs)
- [X] 기능 삭제 (Delete)


## 📝작업 내용
월간 달력의 기록 작성일에 체크박스 표시
- API에서 보낸 응답에서 creationDate 값들만 추출하여 recordDayList 배열에 값 업데이트
- ui 테스트용 배열 삭제
- runtime error 발생해서 memberId 바뀔 때마다 recordDayList 업데이트하도록 변경

체크박스 뜬 날짜에는 일간 도약기록 조회 화면으로 이동
- MonthlyCalendar의 router.query에서 dayToSelect를 가져와서 dayToSelect 변경 시 useEffect 실행


## 스크린샷(선택)
- 기록 작성일에 체크 박스 정상적으로 표시됨
![image](https://github.com/user-attachments/assets/aa288b56-4bf3-42cb-8ec7-df0413a6f66d)
- 기록이 작성된 일자인 경우 해당 일자의 일간 기록 조회 화면으로 이동(예시: 11월 1일)
![image](https://github.com/user-attachments/assets/4b02f9d1-f692-4276-a616-d4071857f64f)



## 💬리뷰 요구사항 / 질문(선택)



## TODO(선택, 다음 작업 예고)
