### PR TITLE
feat, refactor: 

### DIFF
--- a/harudoyak/src/apis/logsApi.ts
+++ b/harudoyak/src/apis/logsApi.ts
@@ -2,7 +2,6 @@
 import axios from "axios";
 import axiosInstance from "./axiosInstance";
 import { useUserStore } from "../store/useUserStore";
-import { uploadToS3 } from "./uploadToS3";
 
 export type RecordItem = {
   logId: number;

--- a/harudoyak/src/components/buttons/UndoXButton.tsx
+++ b/harudoyak/src/components/buttons/UndoXButton.tsx
@@ -4,10 +4,16 @@
 
 // Dev Log
 // 최초 작성일/작성자: 2024.10.25./루이
-// 수정일/작성자: 2024.10.30/카일
+
+// 1차 수정일/작성자: 2024.10.30/카일
 // 마이페이지의 경우 UndoX와 같은 기능을 쓰나 '<' 이미지를 사용해서
 // 같은 기능을 가진 컴포넌트를 두개 만들지 않고 props로 이미지만 바꿀 수 있게 수정했습니다.
 // <UndoXButton icon={이미지}/> 이런식으로 사용하시면 됩니다.
+
+// 2차 수정일/작성자: 2024.11.15/루이
+// 이전 페이지로 하면 가끔 원하지 않은 곳으로 가게 되는 경우가 있어서 path props를 추가하였습니다.
+// 이전 페이지로 돌아가게 하고 싶은 경우, 똑같이 <UndoXButton icon={이미지}/>라고 작성해 주시면 되고,
+// 특정한 경로로 지정하고 싶을 경우에는, <UndoXButton icon={이미지} path="/grow-check"}> 이렇게 사용하시면 됩니다.
 
 import { useRouter } from "next/router";
 import Image from "next/image";
@@ -15,14 +21,26 @@ import Image from "next/image";
 interface UndoButtonProps {
   icon: string;
   altText?: string;
+  path?: string;
 }
 
-const UndoXButton: React.FC<UndoButtonProps> = ({ icon, altText = "닫기" }) => {
+const UndoXButton: React.FC<UndoButtonProps> = ({
+  icon,
+  altText = "닫기",
+  path,
+}) => {
   const router = useRouter();
 
+  const handleClick = () => {
+    if (path) {
+      router.push(path); // path가 있으면 특정 페이지로 이동
+    } else {
+      router.back(); // path가 없으면 이전 페이지로 이동
+    }
+  };
   return (
     <>
-      <button type="button" onClick={() => router.back()}>
+      <button type="button" onClick={handleClick}>
         <Image src={icon} alt={altText} />
       </button>
     </>

--- a/harudoyak/src/components/buttons/WritingEntryButton.tsx
+++ b/harudoyak/src/components/buttons/WritingEntryButton.tsx
@@ -9,13 +9,19 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import styled from "styled-components";
 import iconPencil from "../../../public/assets/common/icon_pencil.svg";
+import { usePostDataContext } from "@/src/context/PostDataContext";
 
 const WritingEntryButton: React.FC = () => {
+  const { resetPostData } = usePostDataContext();
   const router = useRouter();
+  const handleClick = () => {
+    resetPostData();
+    router.push("/grow-up-record");
+  };
 
   return (
     <ButtonLayout>
-      <button type="button" onClick={() => router.push("/grow-up-record")}>
+      <button type="button" onClick={handleClick}>
         <ContentWrapper>
           <Image src={iconPencil} alt="도약기록 쓰기 아이콘" />
           <Text>도약기록 쓰기</Text>

--- a/harudoyak/src/components/grow-up-record/Emotions.tsx
+++ b/harudoyak/src/components/grow-up-record/Emotions.tsx
@@ -32,49 +32,47 @@ const Emotions: React.FC<EmotionsProps> = ({ emotion, updateEmotion }) => {
 
   const [isOpened, setIsOpened] = useState<boolean>(true); // pop message open 여부
 
-  //const router = useRouter();
-
   return (
     <Root>
       <StyledBtn
         $isSelected={emotion === "love"}
-        onClick={() => handleClick("love")}
+        onClick={() => handleClick("hearts")}
       >
         <Image src={love} alt="사랑" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "happy"}
-        onClick={() => handleClick("happy")}
+        onClick={() => handleClick("laughing")}
       >
         <Image src={happy} alt="기쁨" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "sad"}
-        onClick={() => handleClick("sad")}
+        onClick={() => handleClick("tear")}
       >
         <Image src={sad} alt="슬픔" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "angry"}
-        onClick={() => handleClick("angry")}
+        onClick={() => handleClick("rage")}
       >
         <Image src={angry} alt="화남" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "surprised"}
-        onClick={() => handleClick("surprised")}
+        onClick={() => handleClick("hushed")}
       >
         <Image src={surprise} alt="놀람" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "fun"}
-        onClick={() => handleClick("fun")}
+        onClick={() => handleClick("star")}
       >
         <Image src={funny} alt="재밌음" />
       </StyledBtn>
       <StyledBtn
         $isSelected={emotion === "etc"}
-        onClick={() => handleClick("etc")}
+        onClick={() => handleClick("question")}
       >
         <Image src={etc} alt="기타" />
       </StyledBtn>

--- a/harudoyak/src/components/grow-up-record/ReloadButton.tsx
+++ b/harudoyak/src/components/grow-up-record/ReloadButton.tsx
@@ -6,15 +6,10 @@ import Image from "next/image";
 
 interface ReloadButtonProps {
   text: string;
-  tags: string[];
   updateTags: (Tags: string[]) => void;
 }
 
-const ReloadButton: React.FC<ReloadButtonProps> = ({
-  text,
-  tags,
-  updateTags,
-}) => {
+const ReloadButton: React.FC<ReloadButtonProps> = ({ text, updateTags }) => {
   const [index, setIndex] = useState(1);
 
   const handleSubmit = async () => {
@@ -52,4 +47,5 @@ const Button = styled.button`
   all: unset;
   cursor: pointer;
   top: 0;
+  min-width: 14px;
 `;

--- a/harudoyak/src/components/grow-up-record/ReloadButton.tsx
+++ b/harudoyak/src/components/grow-up-record/ReloadButton.tsx
@@ -1,16 +1,41 @@
-import React from "react";
+import axios from "axios";
+import React, { useState } from "react";
 import styled from "styled-components";
 import iconReload from "../../../public/assets/common/icon_reload.svg";
 import Image from "next/image";
 
 interface ReloadButtonProps {
-  index: number;
+  text: string;
+  tags: string[];
+  updateTags: (Tags: string[]) => void;
 }
 
-const ReloadButton: React.FC<ReloadButtonProps> = ({ index }) => {
+const ReloadButton: React.FC<ReloadButtonProps> = ({
+  text,
+  tags,
+  updateTags,
+}) => {
+  const [index, setIndex] = useState(1);
+
   const handleSubmit = async () => {
-    console.log("태그 다시 불러오기");
-    index = index + 1;
+    try {
+      const response = await axios.post("/api/openai/keywords", { text });
+
+      if (response.status === 200) {
+        if (index >= 3) {
+          return alert("도약태그는 최대 3번까지 재설정 가능합니다.");
+        } else {
+          const tags = response.data.keywords;
+          updateTags(tags);
+          console.log(tags);
+        }
+      } else {
+        console.error("태그 키워드를 가져오는 데 실패했습니다.");
+      }
+    } catch (error) {
+      console.error("error: ", error);
+    }
+    setIndex(index + 1);
     console.log(index + "번째 호출");
   };
 

--- a/harudoyak/src/components/grow-up-record/TextEntryButton.tsx
+++ b/harudoyak/src/components/grow-up-record/TextEntryButton.tsx
@@ -10,7 +10,6 @@ const TextEntryButton: React.FC<TextEntryButtonProps> = ({ children }) => {
     <Root>
       <EntryButton>
         {children}
-        {/*TODO : 도약 기록 작성 후에는 disabled로 바꿔서 수정 버튼을 통해 접근할 수 있도록 구현*/}
       </EntryButton>
     </Root>
   );
@@ -33,7 +32,7 @@ const EntryButton = styled.button`
   font-size: 0.94rem;
   align-items: flex-start;
   margin-right: 23px;
-
+  margin-bottom: 23px;
 `;
 
 const Span = styled.span`

--- a/harudoyak/src/components/grow-up-record/UploadImage/UploadSection.tsx
+++ b/harudoyak/src/components/grow-up-record/UploadImage/UploadSection.tsx
@@ -9,7 +9,7 @@ import cameraIcon from "../../../../public/assets/grow-up-record/icon_camera.svg
 import imageIcon from "../../../../public/assets/grow-up-record/icon_image.svg";
 
 interface UploadSectionProps {
-  image: string;
+  image: string | null;
   updateImage: (image: string) => void;
 }
 

--- a/harudoyak/src/context/PostDataContext.tsx
+++ b/harudoyak/src/context/PostDataContext.tsx
@@ -6,6 +6,7 @@ export interface PostDataContextType extends PostData {
   updateEmotion: (newEmotion: string) => void;
   updateImage: (newImage: string | null) => void;
   updateTags: (newTags: string[]) => void;
+  resetPostData: () => void;
 }
 
 const PostDataContext = createContext<PostDataContextType | undefined>(
@@ -26,6 +27,13 @@ export const PostDataProvider: React.FC<{ children: React.ReactNode }> = ({
     updateTags,
   } = usePostData();
 
+  const resetPostData = () => {
+    updateEmotion("");
+    updateImage(null);
+    updateTags([]);
+    updateText("");
+  };
+
   return (
     <PostDataContext.Provider
       value={{
@@ -37,6 +45,7 @@ export const PostDataProvider: React.FC<{ children: React.ReactNode }> = ({
         updateEmotion,
         updateImage,
         updateTags,
+        resetPostData,
       }}
     >
       {children}

--- a/harudoyak/src/context/PostDataContext.tsx
+++ b/harudoyak/src/context/PostDataContext.tsx
@@ -4,7 +4,7 @@ import usePostData, { PostData } from "../hooks/usePostData";
 export interface PostDataContextType extends PostData {
   updateText: (newText: string) => void;
   updateEmotion: (newEmotion: string) => void;
-  updateImage: (newImage: File | null) => void;
+  updateImage: (newImage: string | null) => void;
   updateTags: (newTags: string[]) => void;
 }
 

--- a/harudoyak/src/hooks/usePostData.ts
+++ b/harudoyak/src/hooks/usePostData.ts
@@ -4,14 +4,14 @@ import { useState } from 'react';
 export interface PostData {
   emotion: string;
   text: string;
-  image: File | null;
+  image: string | null;
   tags: string[];
 }
 
 const usePostData = () => {
   const [emotion, setEmotion] = useState<string>("");
   const [text, setText] = useState<string>('');
-  const [image, setImage] = useState<File | null>(null);
+  const [image, setImage] = useState<string | null>(null);
   const [tags, setTags] = useState<string[]>([]);
 
   // 감정 업데이트 함수
@@ -21,7 +21,7 @@ const usePostData = () => {
   const updateText = (newText: string) => setText(newText);
 
   // 이미지 업데이트 함수
-  const updateImage = (newImage: File | null) => setImage(newImage);
+  const updateImage = (newImage: string | null) => setImage(newImage);
 
    // 태그 업데이트 함수
   const updateTags = (newTags: string[]) => setTags(newTags);

--- a/harudoyak/src/pages/grow-up-record/index.tsx
+++ b/harudoyak/src/pages/grow-up-record/index.tsx
@@ -43,7 +43,7 @@ const GrowUpRecordHome: React.FC = () => {
       <div
         style={{ width: "100%", display: "flex", flexDirection: "row-reverse" }}
       >
-        <UndoXButton icon={iconX} />
+        <UndoXButton icon={iconX} path="/grow-check" />
       </div>
       <Heading3>오늘의 도약을 기록해 주세요.</Heading3>
 

--- a/harudoyak/src/pages/grow-up-record/index.tsx
+++ b/harudoyak/src/pages/grow-up-record/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../components/grow-up-record";
 
 const GrowUpRecordHome: React.FC = () => {
-  const { text, image, emotion, tags, updateImage, updateEmotion} =
+  const { text, image, emotion, tags, updateImage, updateEmotion, updateTags } =
     usePostDataContext();
   // TODO: 도약기록 페이지 들어올 때마다 tags를 초기화하는 state 변수
 
@@ -63,8 +63,7 @@ const GrowUpRecordHome: React.FC = () => {
           </ReactMarkdown>
         </TextEntryButton>
       </Link>
-
-      <ImageUploadSection image={image} updateImage={updateImage}/>
+      {image && <ImageUploadSection image={image} updateImage={updateImage} />}
 
       <FlexWrapper>
         <Heading2 style={{ marginTop: "5px", marginBottom: "5px" }}>
@@ -83,7 +82,13 @@ const GrowUpRecordHome: React.FC = () => {
         ) : (
           <P>아직 출력된 태그가 없습니다.</P>
         )}
-        <ReloadButton index={index} />
+        <ReloadButton
+          index={index}
+          text={text}
+          tags={tags}
+          updateTags={updateTags}
+        />
+        {/*태그가 업데이트 되면 자동으로 반영될 수 있도록 useEffect 사용하기*/}
       </FlexWrapper>
       {isReadyToSubmit && (
         <SubmitButton

--- a/harudoyak/src/pages/grow-up-record/index.tsx
+++ b/harudoyak/src/pages/grow-up-record/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
@@ -25,7 +25,6 @@ import {
 const GrowUpRecordHome: React.FC = () => {
   const { text, image, emotion, tags, updateImage, updateEmotion, updateTags } =
     usePostDataContext();
-  // TODO: 도약기록 페이지 들어올 때마다 tags를 초기화하는 state 변수
 
   const [isTooltipOpened, setIsTooltipOpened] = useState<boolean>(false);
 
@@ -38,7 +37,6 @@ const GrowUpRecordHome: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
   const clickModal = () => setShowModal(!showModal);
   const isReadyToSubmit = text && emotion && tags && tags.length > 0;
-  const [index, setIndex] = useState(0);
 
   return (
     <Root>
@@ -63,10 +61,10 @@ const GrowUpRecordHome: React.FC = () => {
           </ReactMarkdown>
         </TextEntryButton>
       </Link>
-      {image && <ImageUploadSection image={image} updateImage={updateImage} />}
+      <ImageUploadSection image={image} updateImage={updateImage} />
 
       <FlexWrapper>
-        <Heading2 style={{ marginTop: "5px", marginBottom: "5px" }}>
+        <Heading2 style={{ marginTop: "7px", marginBottom: "5px" }}>
           오늘의 도약 태그
         </Heading2>
         <Tooltip
@@ -82,13 +80,7 @@ const GrowUpRecordHome: React.FC = () => {
         ) : (
           <P>아직 출력된 태그가 없습니다.</P>
         )}
-        <ReloadButton
-          index={index}
-          text={text}
-          tags={tags}
-          updateTags={updateTags}
-        />
-        {/*태그가 업데이트 되면 자동으로 반영될 수 있도록 useEffect 사용하기*/}
+        <ReloadButton text={text} updateTags={updateTags} />
       </FlexWrapper>
       {isReadyToSubmit && (
         <SubmitButton


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가 (Feat)
- [x] 코드 구조 등 리팩토링 (Refactor)
- [x] 스타일 추가 및 수정 (Style)


## 📝작업 내용
- 특정 페이지로 라우팅 되어야 하는 UndoXButton 기능을 구현하기 위해 path props를 추가하였습니다.
 1️⃣ 이전 페이지로 돌아가게 하고 싶은 경우, 똑같이 `<UndoXButton icon={이미지}/>`라고 작성해 주시면 되고,
 2️⃣ 특정한 경로로 지정하고 싶을 경우에는, `<UndoXButton icon={이미지} **path="/grow-check"**}>` 이렇게 사용하시면 됩니다.

- 도약기록 작성 페이지 들어갈 때 남아있던 이전 태그, 감정, 텍스트 데이터를 초기화하는 로직 추가
-  도약 태그 reload 기능 추가(3번 이상 reload 시 alert 띄움)


## 스크린샷(선택)



## 💬리뷰 요구사항 / 질문(선택)



## TODO(선택, 다음 작업 예고)
