### PR TITLE
style, feat: week/month 도약기록 확인 스타일 통일, 비정상적인 태그 예외 처리

### DIFF
--- a/harudoyak/src/components/buttons/WritingEntryButton.style.ts
+++ b/harudoyak/src/components/buttons/WritingEntryButton.style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const ButtonLayout = styled.div`
+  z-index: 1;
+  position: fixed;
+  bottom: 100px;
+  right: 20px;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  background-color: var(--main-green);
+  padding: 15px 15px;
+  border-radius: 55px;
+  border: 1px solid #ccc;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  justify-content: center;
+`;

--- a/harudoyak/src/components/buttons/WritingEntryButton.tsx
+++ b/harudoyak/src/components/buttons/WritingEntryButton.tsx
@@ -3,12 +3,13 @@
 // 주 사용처: 홈 화면, 도약기록 확인 탭의 하단 '도약기록 쓰기'버튼
 
 // Dev Log
-// 최초 작성일/작성자: 2024.11.01./루이
-// 수정일/작성자/수정 내용: 2024.11.22./루이/오늘 이미 작성한 로그가 있으면 작성페이지에 들어가지 못하도록 설계
+// 최초 작성일/작성자: 2024.11.01/루이
+// 수정일/작성자/수정 내용: 2024.11.22/루이/오늘 이미 작성한 로그가 있으면 작성페이지에 들어가지 못하도록 설계
 
 import { useRouter } from "next/router";
 import Image from "next/image";
-import styled, { CSSProperties } from "styled-components";
+import { CSSProperties } from "styled-components";
+import * as S from "./WritingEntryButton.style";
 import iconPencil from "../../../public/assets/common/icon_pencil.svg";
 import { usePostDataContext } from "@/src/context/PostDataContext";
 import useLogsStore from "@/src/store/useLogStore";
@@ -38,17 +39,17 @@ const WritingEntryButton: React.FC<WritingEntryButtonProps> = ({ onFail }) => {
   };
 
   return (
-    <ButtonLayout>
+    <S.ButtonLayout>
       <button type="button" onClick={handleClick}>
-        <ContentWrapper>
+        <S.ContentWrapper>
           <Image
             src={iconPencil}
             alt="도약기록 쓰기 아이콘"
             style={imageStyle}
           />
-        </ContentWrapper>
+        </S.ContentWrapper>
       </button>
-    </ButtonLayout>
+    </S.ButtonLayout>
   );
 };
 
@@ -57,22 +58,3 @@ export default WritingEntryButton;
 const imageStyle: CSSProperties = {
   left: "50%",
 };
-
-const ButtonLayout = styled.div`
-  z-index: 1;
-  position: fixed;
-  bottom: 100px;
-  right: 20px;
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  background-color: var(--main-green);
-  padding: 15px 15px;
-  border-radius: 55px;
-  border: 1px solid #ccc;
-  align-items: center;
-  width: 30px;
-  height: 30px;
-  justify-content: center;
-`;

--- a/harudoyak/src/components/common/Tag.tsx
+++ b/harudoyak/src/components/common/Tag.tsx
@@ -30,4 +30,7 @@ const StyledTag = styled.div`
   color: var(--main-green);
   white-space: nowrap;
   font-size: 0.85rem;
+  max-width: 350px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/harudoyak/src/components/growcheck/Feel.style.ts
+++ b/harudoyak/src/components/growcheck/Feel.style.ts
@@ -45,7 +45,7 @@ export const MailWrapper = styled.div`
   border-radius: 10px;
   background: linear-gradient(90deg, rgba(210, 205, 100, 0.10) 0%, rgba(110, 173, 107, 0.10) 100%);
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.10);
-    margin-bottom: 6rem;
+  margin-bottom: 5px;
 `;
 
 export const PotImageWrapper = styled.div`
@@ -60,4 +60,19 @@ export const ParellelWrapper = styled.div`
   justify-content: left;
   align-items: center;
   gap: 1rem;
+`;
+
+export const Margin = styled.div`
+  width: 100%;
+  height: 5px;
+`;
+
+export const BigMargin = styled.div`
+  width: 100%;
+  height: 50px;
+`;
+
+export const BottomMargin = styled.div`
+  width: 100%;
+  height: 6rem;
 `;

--- a/harudoyak/src/components/growcheck/Mailbox.tsx
+++ b/harudoyak/src/components/growcheck/Mailbox.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import messageIcon from "../../Images/messageIcon.png";
 import Image from "next/image";
+import { MailWrapper } from "./Feel.style";
 
 interface MailProps {
   date?: Date;
@@ -33,15 +34,6 @@ const MailBox: React.FC<MailListProps> = ({ mailList }) => {
   );
 };
 export default MailBox;
-
-const MailWrapper = styled.div`
-  background-color: #e6efe5;
-  border-radius: 2rem;
-  padding: 1rem;
-  color: #767676;
-  margin-bottom: 1rem;
-  box-shadow: 0.2rem 0.2rem 0.2rem 0.2rem #d5d5d5;
-`;
 
 const UpperItems = styled.div`
   display: flex;

--- a/harudoyak/src/components/growcheck/MonthFeel.tsx
+++ b/harudoyak/src/components/growcheck/MonthFeel.tsx
@@ -62,6 +62,7 @@ const MonthFeel: React.FC<MonthProps> = ({ selectedDate }) => {
         <S.SectionTitle>이번 달 하루도약</S.SectionTitle>
         <Circle number={aiFeedbackCount}></Circle>
       </S.ParellelWrapper>
+      <S.BottomMargin />
     </S.Container>
   );
 };

--- a/harudoyak/src/components/growcheck/MonthFeel.tsx
+++ b/harudoyak/src/components/growcheck/MonthFeel.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
 import * as S from "./Feel.style";
 import EmotionDiv from "./EmotionDiv";
-import Tags from "./Tags";
-//import Tags from '../components/'
+import Tags from "../common/Tags";
 import Circle from "./Circle";
 import { MonthlyRecord } from "@/src/apis/logsApi";
 import { format } from "date-fns";
@@ -53,11 +52,16 @@ const MonthFeel: React.FC<MonthProps> = ({ selectedDate }) => {
     fetchMonthly();
   }, [selectedDate]);
   return (
-    <S.Container>
+    <S.Container style={{ marginTop: "30px" }}>
       <S.SectionTitle>이번 달의 감정</S.SectionTitle>
+      <S.Margin />
+      <S.Margin />
       <EmotionDiv emotions={emotion} type="Month" />
+      <S.BigMargin />
       <S.SectionTitle>이번 달 도약태그</S.SectionTitle>
-      <Tags tags={monthTags} />
+      <S.Margin />
+      <Tags tagslist={monthTags} />
+      <S.BigMargin />
       <S.ParellelWrapper>
         <S.SectionTitle>이번 달 하루도약</S.SectionTitle>
         <Circle number={aiFeedbackCount}></Circle>

--- a/harudoyak/src/components/growcheck/TodayFeel.tsx
+++ b/harudoyak/src/components/growcheck/TodayFeel.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import * as S from "./Feel.style";
 import { format } from "date-fns";
 import EmotionDiv from "./EmotionDiv";
-//import Tags from "./Tags";
 import Tags from "../common/Tags";
 import pot from "../../../public/assets/grow-up-record/pot.svg";
 
@@ -125,6 +124,7 @@ const TodayFeel: React.FC<TodayProps> = ({ selectedDay }) => {
           <Image src={pot} width={50} height={50} alt="pot" />
         </S.PotImageWrapper>
       </S.MailWrapper>
+      <S.BottomMargin />
     </S.Container>
   );
 };

--- a/harudoyak/src/components/growcheck/WeekFeel.tsx
+++ b/harudoyak/src/components/growcheck/WeekFeel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import * as S from "./Feel.style";
-import Tags from "./Tags";
+import Tags from "../common/Tags";
 import EmotionDiv from "./EmotionDiv";
 import Mailbox from "./Mailbox";
 import Circle from "./Circle";
@@ -28,7 +28,7 @@ const WeekFeel: React.FC<WeekProps> = ({ selectedDate }) => {
 
         if (response) {
           const tags = response.tags
-            .slice(0, 6)
+            .slice(0, 12)
             .map((tag: { tagName: string }) => tag.tagName);
           setWeeklyTags(tags);
 
@@ -63,17 +63,26 @@ const WeekFeel: React.FC<WeekProps> = ({ selectedDate }) => {
     <S.Container>
       <S.SectionTitle>이번주의 감정</S.SectionTitle>
       <EmotionDiv emotions={emotion} type="Week" />
+      <S.BigMargin />
+
       <S.SectionTitle>이번주 도약 태그</S.SectionTitle>
-      <Tags tags={weeklyTags} />
+      <S.Margin />
+      <Tags tagslist={weeklyTags} />
+      <S.BigMargin />
+
       <S.ParellelWrapper>
         <S.SectionTitle>이번주 하루도약</S.SectionTitle>
         <Circle number={mailList.length} />
       </S.ParellelWrapper>
+      <S.BigMargin />
+
       <S.ParellelWrapper>
         <S.SectionTitle>도약이의 우체통</S.SectionTitle>
         <Circle number={mailList.length} />
       </S.ParellelWrapper>
+      <S.Margin />
       <Mailbox mailList={mailList || []} />
+      <S.BottomMargin />
     </S.Container>
   );
 };


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [x] 기능 추가 (Feat)
- [x] 스타일 추가 및 수정 (Style)



## 📝작업 내용
주별, 월별 도약기록 확인 스타일 통일하였습니다.
비정상적으로 긴 태그의 경우  모두 출력하는 것이 아닌 ... 말줄임표로 나오도록 변경하였습니다. 


## 스크린샷(선택)
<img width="309" alt="스크린샷 2024-11-26 오후 5 05 17" src="https://github.com/user-attachments/assets/2744732b-5632-4c79-a6a0-0e2ba8cb66a4">
<img width="309" alt="스크린샷 2024-11-26 오후 5 05 10" src="https://github.com/user-attachments/assets/eb223899-2c66-40dc-b716-c8f7631a0ac3">



## 💬리뷰 요구사항 / 질문(선택)



## TODO(선택, 다음 작업 예고)
